### PR TITLE
Changed the outdir of the config file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "target": "es5",
         "module": "commonjs",
         "strict": true,
-        "outDir": "./dist",
+        "outDir": "dist",
         "esModuleInterop": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
Issue: When npm building, a new dist folder would be created for every folder that had a typescript file to be compiled

Solution: Changed the outdir in the config file to "dist" from "./dist"