### PR TITLE
increased size of payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "A scheduling tool",
     "main": "server.js",
     "dependencies": {
+        "body-parser": "^1.19.0",
         "dotenv": "^8.2.0",
         "esm": "^3.2.25",
         "express": "^4.17.1",

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,9 @@ const app = express();
 const port = process.env.PORT || 3001;
 
 // Setup body-parser
-app.use(express.json());
+const bodyParser = require("body-parser");
+app.use(bodyParser.json({ limit: "50mb" }));
+app.use(bodyParser.urlencoded({ limit: "50mb", extended: true }));
 
 // Setup our routes.
 app.use("/", routes);
@@ -24,7 +26,7 @@ if (process.env.MONGO_URI == null) {
         })
         .then(() =>
             app.listen(port, () =>
-                console.log(`App server listening on port ${port}!`)
-            )
+                console.log(`App server listening on port ${port}!`),
+            ),
         );
 }


### PR DESCRIPTION
Issue: The payload was set to the default of 100kb which is too small for our application especially with the large ics files that may be uploaded and returned

Solution: Increased the payload by using a new body-parser and set the limit to 50mb